### PR TITLE
Closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
+## v1.1.1 [2024-02-02]
+
+- Fix issue #4: if the template binary file had been stored to disk by N8N (as opposed to keeping it in memory), the Render operation would fail with the error `ERROR: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise`. This was due to [a breaking change in N8N v1.9.0](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-CHANGES.md#what-changed-3). Thanks to [@altvk88](https://github.com/altvk88) for reporting the issue and helping diagnose it!
+
 ## v1.1.0 [2023-08-25]
 
-* Add the ability to set [render options](https://carbone.io/api-reference.html#options). Thanks, [@mrtnblv](https://github.com/mrtnblv)!
+- Add the ability to set [render options](https://carbone.io/api-reference.html#options). Thanks, [@mrtnblv](https://github.com/mrtnblv)!
 
 ## v1.0.1 [2023-05-30]
 
-* Add docs suggesting alternative for PDF rendering when running N8N on Docker (i.e. Gotenberg)
+- Add docs suggesting alternative for PDF rendering when running N8N on Docker (i.e. Gotenberg)
 
 ## v1.0.0 [2023-50-27]
 
-* Initial release
+- Initial release

--- a/nodes/CarboneNode/CarboneNode.node.ts
+++ b/nodes/CarboneNode/CarboneNode.node.ts
@@ -6,9 +6,9 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
+	BINARY_ENCODING,
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
-import { BINARY_ENCODING } from 'n8n-workflow';
 import { convertDocumentToPdf, isWordDocument, renderDocument, buildOptions } from './CarboneUtils';
 
 const nodeOperations: INodePropertyOptions[] = [
@@ -190,8 +190,10 @@ export class CarboneNode implements INodeType {
 					}
 					let fileContent: Buffer | Readable;
 					if (binaryData.id) {
-						fileContent = this.helpers.getBinaryStream(binaryData.id);
+						console.log(`Reading from file, id=${binaryData.id}`);
+						fileContent = await this.helpers.getBinaryStream(binaryData.id);
 					} else {
+						console.log(`Reading directly into buffer, size=${binaryData.data.length}`);
 						fileContent = Buffer.from(binaryData.data, BINARY_ENCODING);
 					}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-carbonejs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Carbone JS node that renders Word templates on n8n.io",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
This PR adds a fix for an error that may appear if N8N is reading the template file (i.e. the DOCX file that is used to generate the document) from disk, as opposed to directly reading it from memory. This cannot be controlled by the plugin and can be forced via an envvar `N8N_DEFAULT_BINARY_DATA_MODE=filesystem` (see <https://docs.n8n.io/hosting/scaling/binary-data/>)

The root cause is that, on v1.9.0, N8N introduced a breaking change so the `this.helpers.getBinaryStream()` function is now `async`: see <https://github.com/n8n-io/n8n/blob/da1fe44d5246848e2ba7bb8bc5f4577685fbcee0/packages/cli/BREAKING-CHANGES.md?plain=1#L63>. This function is indeed [called by this plugin](https://github.com/jreyesr/n8n-nodes-carbonejs/blob/d6f5b36e660c5720cf28651e338ade9577c04b18/nodes/CarboneNode/CarboneNode.node.ts#L193), at more or less the correct place to cause errors. Furthermore, v1.9.0 was released [at the end of September 2023](https://github.com/n8n-io/n8n/releases?q=1.9.0&expanded=true), while the bulk of this plugin's code, including the offending line, is from May 2023 ([see blame view](https://github.com/jreyesr/n8n-nodes-carbonejs/blame/d6f5b36e660c5720cf28651e338ade9577c04b18/nodes/CarboneNode/CarboneNode.node.ts#L193)), so the timeline checks out: this wasn't caught because it Used To Work, and I didn't notice that it started failing because I use raw JS code instead of the plugin because of #1 (which, incidentally, seems to have fixed itself for mysterious reasons)