### PR TITLE
Closes #7 and #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.1.2 [2024-09-17]
+
+- Fix issue #7: sometimes, under unclear circumstances, rendering failed with an error `NodeOperationError: Unknown input file type`.
+  Thanks to [@JV300381](https://github.com/JV300381) for reporting the issue and helping confirm that it was solved!
+
 ## v1.1.1 [2024-02-02]
 
 - Fix issue #4: if the template binary file had been stored to disk by N8N (as opposed to keeping it in memory), the Render operation would fail with the error `ERROR: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise`. This was due to [a breaking change in N8N v1.9.0](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-CHANGES.md#what-changed-3). Thanks to [@altvk88](https://github.com/altvk88) for reporting the issue and helping diagnose it!

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ You must have a local (non-Docker) installation of N8N.
 1. After making changes in the code and rebuilding, you'll need to stop N8N (Ctrl+C) and restart it (`n8n start`)
 1. For faster changes, instead of rebuilding the code each time, run `npm run dev`. This will start the TypeScript compiler in watch mode, which will recompile the code on every change. You'll still need to restart N8N manually, though.
 
+### Small-scale release for single person
+
+Use when someone has reported an issue, to give that person a way to test the fix
+without having to release a version that may not fix their issue. Especially useful
+when the issue can't be reproduced locally.
+
+1. Temporarily edit the `package.json` file to another version, e.g. `v1.2.3-bugfix123`
+2. Run `npm ci && npm run build && npm publish --tag prerelease`
+3. This will build and upload a new release to NPM, _without marking it_ as the latest release! This is important
+   because otherwise other users of the node will start getting prompts to update their installations, which isn't correct
+4. Tell the user that may be interested in testing the changes to force-install that new version
+5. If/when the user confirms that the version fixes the issue, release for everyone: [see below](#releasing-changes)
+
 ### Releasing changes
 
 - [ ] Bump the version in `package.json`. We use [SemVer](https://semver.org/).

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ You must have a local (non-Docker) installation of N8N.
 1. Make changes as required
 1. `npm run build`
 1. `npm link`
-1. Go to N8N's install dir (`~/.n8n/nodes/` on Linux), then run `npm link n8n-nodes-carbonejs`
+1. Go to N8N's install dir (`~/.n8n/custom/` on Linux), then run `npm link n8n-nodes-carbonejs`
 1. `n8n start`. If you need to start the N8N instance on another port, `N8N_PORT=5679 n8n start`
 1. There's no need to visit the web UI to install the node: it's already installed since it lives in the correct directory
 1. After making changes in the code and rebuilding, you'll need to stop N8N (Ctrl+C) and restart it (`n8n start`)

--- a/nodes/CarboneNode/CarboneUtils.ts
+++ b/nodes/CarboneNode/CarboneUtils.ts
@@ -17,7 +17,7 @@ const withTempDir = async <T>(fn: (dirPath: string) => T): Promise<T> => {
 	try {
 		return await fn(dir);
 	} finally {
-		fs.rmdir(dir, { recursive: true });
+		await fs.rm(dir, { recursive: true });
 	}
 };
 
@@ -44,7 +44,7 @@ const renderDocument = async (
 	document: Buffer | Readable,
 	context: any,
 	options: object,
-): Promise<Buffer | Readable> => {
+): Promise<Buffer> => {
 	return withTempFile(async (file) => {
 		await fs.writeFile(file, document); // Save the template to temp dir, since Carbone needs to read from disk
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-carbonejs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A Carbone JS node that renders Word templates on n8n.io",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
This PR updates the way in which the node reads binary data, since it was using a way that failed for unknown reasons on some N8N installations (but not on mine, of course...)

The node now uses the same method that is used by the Extract from File first-party nodes, so it should work.

It also fixed the fact that the items that are output by the node were actually the same as the input items, such that after running the node, the item that was on its Input also had the rendered document as a Binary file. This caused confusion and was sometimes a source of issues if the same key (e.g. `data`) was used for both the input and output documents, because then the template that was on the Input was overwritten with the rendered document on the Output